### PR TITLE
Bugfix: index expects default export

### DIFF
--- a/src/core/composers/keyIn.js
+++ b/src/core/composers/keyIn.js
@@ -1,6 +1,6 @@
 import Immutable from 'immutable'
 
-export function keyIn(keys) {
+export default function keyIn(keys) {
   const keySet = Immutable.Set(keys)
   return (value, key) => {
     return keySet.has(key)


### PR DESCRIPTION
For me, e.g. `omit` is broken:
> TypeError: (0 , _composers.keyIn) is not a function

The reason seems to be, that the local index.js here expects a default export of `keyIn`.

Feel free to close this PR of the bug should be fixed differently.